### PR TITLE
Fix for Laravel 5.2

### DIFF
--- a/src/Vendor/Laravel/ServiceProvider.php
+++ b/src/Vendor/Laravel/ServiceProvider.php
@@ -5,6 +5,7 @@ namespace PragmaRX\ZipCode\Vendor\Laravel;
 use PragmaRX\ZipCode\ZipCode;
 use PragmaRX\ZipCode\Support\Http;
 use PragmaRX\ZipCode\Support\Finder;
+use Illuminate\Foundation\Application;
 use PragmaRX\Support\ServiceProvider as PragmaRXServiceProvider;
 
 class ServiceProvider extends PragmaRXServiceProvider {
@@ -74,7 +75,8 @@ class ServiceProvider extends PragmaRXServiceProvider {
 	 */
 	private function registerZipCode()
 	{
-		$this->app[$this->packageName] = $this->app->bindShared(
+		$method = version_compare(Application::VERSION, '5.2', '>=') ? 'singleton' : 'bindShared';
+		$this->app[$this->packageName] = $this->app->$method(
 			'PragmaRX\ZipCode\Contracts\ZipCode',
 			function($app)
 			{


### PR DESCRIPTION
bindShared() method has been removed in Laravel 5.2 - uses singleton() if Laravel version >= 5.2
